### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,6 @@ module.exports = function (grunt) {
             'assemble',
             'clean:server',
             'concurrent:server',
-            'autoprefixer',
             'connect:livereload',
             'open',
             'watch'
@@ -70,14 +69,16 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask('build', [
+        'clean:assemble',
+        'assemble',
         'clean:dist',
         'useminPrepare',
         'compass:dist',
-        'concurrent:dist',
         'autoprefixer',
         'concat',
         'cssmin',
         'uglify',
+        'concurrent:dist',
         'copy:dist',
         'usemin',
         'modernizr:dist'


### PR DESCRIPTION
concurrent:dist was running before other important tasks like autoprefixer. Moved farther down the order. Removed autoprefixer from the server tasks since it runs on build. Faster server time is more important than browser support at the development stage.
